### PR TITLE
Support pre-instruction and post-instruction hooks in emu.step()

### DIFF
--- a/libmwemu/src/emu.rs
+++ b/libmwemu/src/emu.rs
@@ -3274,6 +3274,14 @@ impl Emu {
         // Run pre-instruction hook
         if let Some(hook_fn) = self.hooks.hook_on_pre_instruction {
             if !hook_fn(self, self.regs.rip, &ins, sz) {
+                // update eip/rip
+                if self.force_reload {
+                    self.force_reload = false;
+                } else if self.cfg.is_64bits {
+                    self.regs.rip += sz as u64;
+                } else {
+                    self.regs.set_eip(self.regs.get_eip() + sz as u64);
+                }
                 return true; // skip instruction emulation
             }
         }


### PR DESCRIPTION
I don't know if it was an intended behaviour, but it turns out emu.step() doesn't call pre-instruction and post-instruction hook so i added it.